### PR TITLE
Pin deployment ruby version to 2.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
   deploy:
     working_directory: ~/work
     docker:
-      - image: circleci/ruby:latest
+      - image: circleci/ruby:2.7.2
     steps:
       - attach_workspace:
           at: ~/work


### PR DESCRIPTION
Pin the Ruby version for the `deploy` job to 2.7.2. The `latest` tag previously used resolved to version 3.0.

I was able to confirm locally that this fixes the s3_website problem.